### PR TITLE
Fix behavior when userId is null or undefined

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,12 @@
+1.7.3 / 2018-08-06
+==================
+
+  * Fix behavior when userId is null or undefined
+
 1.7.2 / 2018-08-03
 ==================
 
-  * Fix tests so tag builds. 
+  * Fix tests so tag builds.
 
 1.7.1 / 2018-08-03
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -198,7 +198,11 @@ Appboy.prototype._changeUser = function(userId, callback) {
   // Actually perform the `changeUser` call. The callback we pass to
   // `appboy.changeUser` will be invoked when in-app messaging is ready.
   var self = this;
-  window.appboy.changeUser(userId, function() {
+
+  // Put the work to be done after `changeUser` completes into a variable. In
+  // some situations, we will have to call this ourselves, as Braze's SDK will
+  // not do so for us.
+  var changeUserCallback = function() {
     // Invoke all the callbacks awaiting for in-app messages to be ready. These
     // callbacks were all enqueued by calling `_onMessagingReady`.
     each(function(callback) {
@@ -211,7 +215,14 @@ Appboy.prototype._changeUser = function(userId, callback) {
     // must be downloaded.
     self._messagingReady = true;
     self._messagingReadyQueue = [];
-  });
+  }
+
+  if (userId == null || userId === undefined) {
+    window.appboy.changeUser(userId);
+    changeUserCallback();
+  } else {
+    window.appboy.changeUser(userId, changeUserCallback);
+  }
 };
 
 // If in-app messages are available, the passed callback will be invoked

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy-ibm",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Hopefully the code speaks for itself.

This issue was discovered while debugging with IBM.